### PR TITLE
adding terraform-docs and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@TV4/cloud-excellence"

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -1,0 +1,50 @@
+name: Terraform docs
+
+on:
+  pull_request:
+    paths:
+      - "**/*.tf"
+
+jobs:
+  module-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.folder-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Generate terraform folder matrix
+        id: folder-matrix
+        run: |
+          # generating JSON list with all terraform module folders
+          MATRIX=$( tree -J -L 2 -d --noreport -f | jq .[].contents[].contents[].name | jq -s '{"modules": .}' )
+
+          # changing variable to one long string only
+          MATRIX=$( echo $MATRIX | jq -c . )
+
+          # printing list of directories
+          echo $MATRIX
+          echo "::set-output name=matrix::$MATRIX"
+
+  terraform-docs:
+    runs-on: ubuntu-latest
+    needs: module-matrix
+    name: "terraform docs: ${{ matrix.modules }}"
+    strategy:
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.module-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Terraform docs for ${{ matrix.modules }}
+        uses: terraform-docs/gh-actions@main
+        with:
+          git-push: true
+          git-commit-message: "terraform-docs: ${{ matrix.modules }} (automated action)"
+          working-dir: ${{ matrix.modules }}


### PR DESCRIPTION
- adding terraform-docs workflow (2a95dcd9e3b15bb0ad92506ae47d6e7cc1a3ce90)
  - using matrix since terraform modules are not inside only one folder
  - docs generation triggering on PRs

- adding dependabot for github-actions (71228530d8e577b68a2792948331199c56735a8c)
  - auto-assign PRs to @TV4/cloud-excellence