### PR TITLE
removing reviewers from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "@TV4/cloud-excellence"


### PR DESCRIPTION
assignment to team doesn't work for team in this cases.