### PR TITLE
dependabot-updater to create PR instead of direct commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: terraform
+    directory: modules/aws-keycloak
+    schedule:
+      interval: daily
+  - package-ecosystem: terraform
     directory: modules/aws-secretsmanager
     schedule:
       interval: daily

--- a/.github/workflows/dependabot-updater.yml
+++ b/.github/workflows/dependabot-updater.yml
@@ -51,6 +51,7 @@ jobs:
             .github/dependabot.yml
           commit-message: "dependabot-updater: automated action"
           branch: dependabot-updater-pr
+          base: main
           delete-branch: true
           title: "dependabot-updater: automated action"
           body: |

--- a/.github/workflows/dependabot-updater.yml
+++ b/.github/workflows/dependabot-updater.yml
@@ -45,8 +45,16 @@ jobs:
           echo '${{ steps.dependabot-to-yaml.outputs.result }}' > .github/dependabot.yml
 
       - name: Commit updated .github/dependabot.yml file
-        uses: EndBug/add-and-commit@v9
+        uses: peter-evans/create-pull-request@v4
         with:
-          add: .github/dependabot.yml
-          default_author: github_actions
-          message: "dependabot-updater: automated action"
+          add-paths: |
+            .github/dependabot.yml
+          commit-message: "dependabot-updater: automated action"
+          branch: dependabot-updater-pr
+          delete-branch: true
+          title: "dependabot-updater: automated action"
+          body: |
+            this is an automated PR created by *.github/workflows/dependabot-updater.yml*
+          labels: |
+            dependencies
+            github-actions


### PR DESCRIPTION
[.github/workflows/dependabot-updater.yml](https://github.com/TV4/tf-modules/blob/main/.github/workflows/dependabot-updater.yml)  to create PR instead of direct commit, since `main` is protected branch.

This is an example PR after a run is made with this fix: #80

Run that failed: [2297863081](https://github.com/TV4/tf-modules/actions/runs/2297863081)